### PR TITLE
Allow Wayland socket access

### DIFF
--- a/org.ksnip.ksnip.yaml
+++ b/org.ksnip.ksnip.yaml
@@ -5,7 +5,7 @@ sdk: org.kde.Sdk
 command: ksnip
 rename-icon: ksnip
 finish-args:
-  - --socket=x11
+  - --socket=fallback-x11
   - --socket=wayland
   - --share=ipc
   - --device=dri

--- a/org.ksnip.ksnip.yaml
+++ b/org.ksnip.ksnip.yaml
@@ -6,6 +6,7 @@ command: ksnip
 rename-icon: ksnip
 finish-args:
   - --socket=x11
+  - --socket=wayland
   - --share=ipc
   - --device=dri
   - --filesystem=host


### PR DESCRIPTION
This is required for native Wayland support (window rendering).

This resolves the issue when running a Wayland session but wayland socket
is inaccessible (the application falls back to X11 I presume):

> Critical: Failed to create wl_display (No such file or directory)
> Info: Could not load the Qt platform plugin "wayland" in "" even though it was found.