### PR TITLE
Drop kde own name

### DIFF
--- a/org.ksnip.ksnip.yaml
+++ b/org.ksnip.ksnip.yaml
@@ -11,7 +11,6 @@ finish-args:
   - --device=dri
   - --filesystem=host
   - --share=network
-  - --own-name=org.kde.* # Show appindicator + Connect wayland screenshot portal
   - --talk-name=org.freedesktop.Notifications # Enable notification in wayland
   - --talk-name=org.gnome.Shell.Screenshot # Connect wayland screenshot portal
   - --talk-name=org.freedesktop.portal.Screenshot # Connect wayland screenshot portal

--- a/org.ksnip.ksnip.yaml
+++ b/org.ksnip.ksnip.yaml
@@ -14,6 +14,7 @@ finish-args:
   - --talk-name=org.freedesktop.Notifications # Enable notification in wayland
   - --talk-name=org.gnome.Shell.Screenshot # Connect wayland screenshot portal
   - --talk-name=org.freedesktop.portal.Screenshot # Connect wayland screenshot portal
+  - --talk-name=org.kde.StatusNotifierWatcher # Tray on KDE
   - --filesystem=/tmp # Copy the screenshots in gnome wayland
 cleanup:
   - "*.a"


### PR DESCRIPTION
Will figure out what is needed for `Connect wayland screenshot portal` but giving access to entire KDE bus cannot be the solution.